### PR TITLE
Add unsigned integer filter tests

### DIFF
--- a/gleam/series/where_test.go
+++ b/gleam/series/where_test.go
@@ -80,6 +80,72 @@ func TestSeries_Where(t *testing.T) {
 		}
 	})
 
+	t.Run("uint32 equal filter", func(t *testing.T) {
+		// Create a builder for uint32 values
+		builder := array.NewUint32Builder(mem)
+		defer builder.Release()
+
+		// Append values
+		builder.AppendValues([]uint32{1, 2, 3, 4, 5}, nil)
+		arr := builder.NewArray()
+		defer arr.Release()
+
+		// Create a series
+		s := NewSeries("test", arr)
+		defer s.Release()
+
+		// Filter where values equal 3
+		result, err := s.Where(utils.Equal, uint32(3))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer result.Release()
+
+		// Check result
+		if result.Len() != 1 {
+			t.Errorf("expected length 1, got %d", result.Len())
+		}
+
+		// Access the underlying array to check values
+		resultArr := result.array.(*array.Uint32)
+		if resultArr.Value(0) != 3 {
+			t.Errorf("expected value 3, got %d", resultArr.Value(0))
+		}
+	})
+
+	t.Run("uint64 equal filter", func(t *testing.T) {
+		// Create a builder for uint64 values
+		builder := array.NewUint64Builder(mem)
+		defer builder.Release()
+
+		// Append values
+		builder.AppendValues([]uint64{1, 2, 3, 4, 5}, nil)
+		arr := builder.NewArray()
+		defer arr.Release()
+
+		// Create a series
+		s := NewSeries("test", arr)
+		defer s.Release()
+
+		// Filter where values equal 3
+		result, err := s.Where(utils.Equal, uint64(3))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defer result.Release()
+
+		// Check result
+		if result.Len() != 1 {
+			t.Errorf("expected length 1, got %d", result.Len())
+		}
+
+		// Access the underlying array to check values
+		resultArr := result.array.(*array.Uint64)
+		if resultArr.Value(0) != 3 {
+			t.Errorf("expected value 3, got %d", resultArr.Value(0))
+		}
+	})
+
 	t.Run("float64 less_equal filter", func(t *testing.T) {
 		// Create a builder for float64 values
 		builder := array.NewFloat64Builder(mem)


### PR DESCRIPTION
## Summary
- add uint32 and uint64 Where filter tests using Arrow builders

## Testing
- `go test ./gleam/series`


------
https://chatgpt.com/codex/tasks/task_e_6890bdc29b04832b8a7dab682e9e4549

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify correct filtering for unsigned integer series types (`uint32` and `uint64`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->